### PR TITLE
Add support for tweaking firefox preferences

### DIFF
--- a/saas/photographer/camera.py
+++ b/saas/photographer/camera.py
@@ -138,11 +138,9 @@ class Camera:
                 steps = int(self._document_height() / 800)
                 for i in range(1, steps):
                     scroll_to = i * 800
-                    if self.viewport_max_height is not None:
-                        if scroll_to >= self.viewport_max_height:
-                            break
                     self._scroll_y_axis(scroll_to)
                     self._wait_for_images_to_load()
+                    time.sleep(0.5)
 
                 # resize the viewport and make sure that it's scrolled
                 # all the way to the top
@@ -154,9 +152,10 @@ class Camera:
                     height = self.viewport_max_height
                 else:
                     height = self._document_height()
+                self._wait_for_images_to_load()
                 self._set_resolution(self.viewport_width, height)
                 self._wait_for_images_to_load()
-                self._scroll_y_axis(-500)
+                self._scroll_y_axis(-height)
                 self._wait_for_resize()
 
             console.dca(f'saving screenshot of {url.to_string()}')

--- a/saas/photographer/camera.py
+++ b/saas/photographer/camera.py
@@ -466,3 +466,7 @@ class UserAgents:
     # masquerading as google bot can trick some website to not serve
     # tons of ads and load faster
     GOOGLEBOT = 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)'
+
+    DEFAULT = 'deafult'
+
+    MAC_FIREFOX = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:66.0) Gecko/20100101 Firefox/66.0'

--- a/saas/photographer/camera.py
+++ b/saas/photographer/camera.py
@@ -272,6 +272,13 @@ class Camera:
             path: PhotoPath object used to retrieve path in data directory
             to save png file in
         """
+        height = self.webdriver.get_window_size()['height']
+        width = self.webdriver.get_window_size()['width']
+        console.dca(f'saving png with viewport resolution [{width}x{height}]')
+        console.dca('png output resolution [{}x{}]'.format(
+            int(width * self.dpi),
+            int(height * self.dpi)
+        ))
         self.webdriver.save_screenshot(path.full_path())
 
     def _set_resolution(self, width: int, height: int):

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -30,12 +30,12 @@ class TestCamera(unittest.TestCase):
         """Test creates a webdriver."""
         self.webdriver_profile = self.camera._create_webdriver_profile()
         self.camera.webdriver = self.camera._create_webdriver(
-            self.webdriver_profile,
-            UserAgents.GOOGLEBOT
+            self.webdriver_profile
         )
 
     def routes_to_url(self):
         """Test routes camera to a url."""
+        self.camera.webdriver.set_page_load_timeout = MagicMock()
         self.camera.webdriver.get = MagicMock()
 
     def uses_javascript_snippets(self):
@@ -57,14 +57,9 @@ class TestCamera(unittest.TestCase):
 
         self.camera.webdriver = self.camera._create_webdriver(
             self.webdriver_profile,
-            UserAgents.GOOGLEBOT
         )
 
         self.assertIsInstance(obj=self.camera.webdriver, cls=webdriver.Firefox)
-        self.webdriver_profile.set_preference.assert_any_call(
-            'general.useragent.override',
-            UserAgents.GOOGLEBOT
-        )
         self.webdriver_profile.set_preference.assert_any_call(
             'dom.popup_maximum',
             0
@@ -225,6 +220,8 @@ class TestCamera(unittest.TestCase):
     def test_camera_can_save_screenshot(self):
         """Test camera can save screenshot."""
         self.creates_webdriver()
+        self.camera.webdriver.get_window_size = MagicMock()
+        self.camera.webdriver.save = MagicMock()
         self.camera.webdriver.save_screenshot = MagicMock()
 
         path = PhotoPath(self.datadir)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2,7 +2,7 @@
 
 from saas.photographer.camera import Camera, Limits
 from saas.photographer.javascript import JavascriptSnippets
-import selenium.webdriver.firefox.firefox_binary
+from selenium.webdriver.firefox.firefox_binary import FirefoxBinary
 from saas.storage.datadir import DataDirectory
 from saas.photographer.photo import PhotoPath
 from unittest.mock import MagicMock, call
@@ -29,7 +29,7 @@ class TestCamera(unittest.TestCase):
 
     def creates_webdriver(self):
         """Test creates a webdriver."""
-        selenium.webdriver.firefox.firefox_binary.FirefoxBinary = MagicMock()
+        FirefoxBinary.__init__ = MagicMock(return_value=None)
         self.webdriver_profile = self.camera._create_webdriver_profile()
         self.camera.webdriver = self.camera._create_webdriver(
             self.webdriver_profile

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -1,7 +1,8 @@
 """Camera test."""
 
-from saas.photographer.camera import Camera, UserAgents, Limits
+from saas.photographer.camera import Camera, Limits
 from saas.photographer.javascript import JavascriptSnippets
+import selenium.webdriver.firefox.firefox_binary
 from saas.storage.datadir import DataDirectory
 from saas.photographer.photo import PhotoPath
 from unittest.mock import MagicMock, call
@@ -28,6 +29,7 @@ class TestCamera(unittest.TestCase):
 
     def creates_webdriver(self):
         """Test creates a webdriver."""
+        selenium.webdriver.firefox.firefox_binary.FirefoxBinary = MagicMock()
         self.webdriver_profile = self.camera._create_webdriver_profile()
         self.camera.webdriver = self.camera._create_webdriver(
             self.webdriver_profile


### PR DESCRIPTION
## Added

- Add support for setting camera dpi (layout.css.devPixelsPerPx)
- Add support for starting firefox in non-headless mode
- Add support for setting firefox user agent
- Add suport for using an existing firefox profile

## Fixed

- Improve loading of images with slower page scan
- Fix bug where saas would crash if firefox failed to load url